### PR TITLE
Fix unexpected syntax error when used in Rollup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
-import { tokTypes as tt, TokenType } from "acorn";
-
 const keyword = "assert";
 
 export function importAssertions(Parser) {
+  // Use supplied version acorn version if present, to avoid
+  // reference mismatches due to different acorn versions. This
+  // allows this plugin to be used with Rollup which supplies
+  // its own internal version of acorn and thereby sidesteps
+  // the package manager.
+  const acorn = Parser.acorn || require("acorn");
+  const { tokTypes: tt, TokenType } = acorn;
+
   return class extends Parser {
     constructor(...args) {
       super(...args);


### PR DESCRIPTION
When this plugin is used in Rollup it failed with an `unexpected token` error. I've traced it down to a mismatch between token type object references that were caused by different versions of `acorn`. Rollup ships with their own internal instance and expects every acorn plugin to use that.

The official `acorn-jsx` plugin uses the same pattern as in this PR: https://github.com/acornjs/acorn-jsx/blob/7fab4ebbc2be22814b968dbdb949eb2a47fa51ec/index.js#L13