### PR TITLE
Only downtranspile for maintained node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "type": "git",
     "url": "https://github.com/xtuc/acorn-import-assertions"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "browserslist": [
+    "maintained node versions"
+  ]
 }


### PR DESCRIPTION
This PR updates the browserslist target for `@babel/preset-env` to only downtranspile if a syntax is not supported in all actively maintained node versions. The most obvious one being that the `class` keyword is supported everywhere, so we don't need to transpile those down all the way to ES5.