### PR TITLE
Add ESM build for native node ESM usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,18 @@
   "description": "Support for import assertions in acorn",
   "main": "lib/index.js",
   "module": "src/index.js",
+  "exports": {
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
+  },
   "scripts": {
     "test": "mocha ./test/index.js",
     "watch": "babel ./src --out-dir ./lib --watch",
-    "prepublish": "babel ./src --out-dir ./lib"
+    "prepublish": "babel ./src --out-dir ./lib && node post-build.js"
   },
   "author": "Sven Sauleau <sven@sauleau.com>",
   "license": "MIT",

--- a/post-build.js
+++ b/post-build.js
@@ -1,0 +1,6 @@
+const fs = require("fs");
+const path = require("path");
+
+const src = path.join(__dirname, "src", "index.js");
+const target = path.join(__dirname, "lib", "index.mjs");
+fs.copyFileSync(src, target);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import _acorn from "acorn";
+
 const keyword = "assert";
 
 export function importAssertions(Parser) {
@@ -6,7 +8,7 @@ export function importAssertions(Parser) {
   // allows this plugin to be used with Rollup which supplies
   // its own internal version of acorn and thereby sidesteps
   // the package manager.
-  const acorn = Parser.acorn || require("acorn");
+  const acorn = Parser.acorn || _acorn;
   const { tokTypes: tt, TokenType } = acorn;
 
   return class extends Parser {


### PR DESCRIPTION
Ran into a few errors under node 12 when attempting to use this library in ESM mode that are addressed with this PR.

- 1ef9c4b Fixes mixed CommonJS and ESM syntax that was introduced in my earlier PR #2 . Since there is no synchronous equivalent in native ESM we need to revert back to use a top-level `import` statement. This import is only used as a fallback to keep the fix of #2 intact.
- f1d4914 Add ESM package entry point in `package.json`. This is necessary to get node to pick up the ESM variants.

Quick explanation:

```js
"exports": {
  // default entry point
  ".": {
    // Since we don't have `"type": "module"` set
    // this file must end in `.mjs` for ESM to work
    // in node natively
    "import": "./lib/index.mjs",
    // CommonJS variant
    "require": "./lib/index.js"
  },
  // If a consumer wants to read version info from our package.json or something
  "./package.json": "./package.json",
  // Fallback for old-style deep imports
  "./": "./"
}
```

Since the contents of the ESM entry point are identical to our source file, we only need to copy the file and rewrite the extension from `.js` to `.mjs`.