### PR TITLE
Exclude test, CI and git specific files in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   "dependencies": {},
   "browserslist": [
     "maintained node versions"
+  ],
+  "files": [
+    "lib",
+    "src"
   ]
 }


### PR DESCRIPTION
This PR ensures that we only publish the necessary files to npm. During package creation npm will include the `README.md` and `package.json` by default, so those don't need to be listed manually.