### PR TITLE
Fix "missing default export in acorn" error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import _acorn from "acorn";
+import * as _acorn from "acorn";
 import { leftCurlyBrace, space } from "charcodes";
 
 const keyword = "assert";


### PR DESCRIPTION
Turns out `acorn` doesn't have a default export. This leads to an import error in node in native ESM mode.

```bash
import _acorn from "acorn";
       ^^^^^^
SyntaxError: The requested module 'acorn' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:105:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:151:5)
    at async Loader.import (node:internal/modules/esm/loader:166:24)
    at async Object.loadESM (node:internal/process/esm_loader:68:5)
```

This error flew a bit under the radar over at the WMR repo, because we always pass our own instance instead of using the default one and therefore never excercised that code path.