### PR TITLE
Fix `prepublish` script not run on `npm publish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "mocha ./test/index.js",
     "watch": "babel ./src --out-dir ./lib --watch",
-    "prepublish": "babel ./src --out-dir ./lib && node post-build.js"
+    "prepublishOnly": "babel ./src --out-dir ./lib && node post-build.js"
   },
   "author": "Sven Sauleau <sven@sauleau.com>",
   "license": "MIT",


### PR DESCRIPTION
Turns out that npm has deprecated `prepublish` in favor of `prepublishOnly`. Quoting from [their docs](https://docs.npmjs.com/cli/v7/using-npm/scripts):


> **prepublish (DEPRECATED)**
>
>    Does not run during npm publish, but does run during npm ci and npm install. See below for more info.
>
> **prepublishOnly**
>
>    Runs BEFORE the package is prepared and packed, ONLY on npm publish.