### PR TITLE
fix: allow any assertion keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "acorn": "^8.4.1",
     "chai": "^4.3.4",
     "mocha": "^9.1.0",
-    "test262": "tc39/test262#07caa4a2df2de1baa72ed56e9329d3f2ea941a6d",
+    "test262": "tc39/test262#47ab262658cd97ae35c9a537808cac18fa4ab567",
     "test262-parser-runner": "^0.5.0"
   },
   "peerDependencies": {

--- a/run_test262.js
+++ b/run_test262.js
@@ -12,29 +12,21 @@ const unsupportedFeatures = [];
 const implementedFeatures = ["import-assertions", "json-modules"];
 
 const whitelist = [
-  // 4 invalid programs did not produce a parsing error (without a corresponding entry in the whitelist file):
+  // 10 invalid programs did not produce a parsing error (without a corresponding entry in the whitelist file):
   "language/import/json-invalid.js (default)",
   "language/import/json-invalid.js (strict mode)",
   "language/import/json-named-bindings.js (default)",
   "language/import/json-named-bindings.js (strict mode)",
+  "language/module-code/early-dup-assert-key-export.js (default)",
+  "language/module-code/early-dup-assert-key-export.js (strict mode)",
+  "language/module-code/early-dup-assert-key-import-nobinding.js (default)",
+  "language/module-code/early-dup-assert-key-import-nobinding.js (strict mode)",
+  "language/module-code/early-dup-assert-key-import-withbinding.js (default)",
+  "language/module-code/early-dup-assert-key-import-withbinding.js (strict mode)",
 
-  // 127 valid programs produced a parsing error (without a corresponding entry in the whitelist file):
-  "language/module-code/import-assertion-key-identifiername.js (default)",
-  "language/module-code/import-assertion-key-identifiername.js (strict mode)",
-  "language/module-code/import-assertion-key-string-double.js (default)",
-  "language/module-code/import-assertion-key-string-double.js (strict mode)",
-  "language/module-code/import-assertion-key-string-single.js (default)",
-  "language/module-code/import-assertion-key-string-single.js (strict mode)",
-  "language/module-code/import-assertion-many.js (default)",
-  "language/module-code/import-assertion-many.js (strict mode)",
+  // 113 valid programs produced a parsing error (without a corresponding entry in the whitelist file):
   "language/module-code/import-assertion-newlines.js (default)",
   "language/module-code/import-assertion-newlines.js (strict mode)",
-  "language/module-code/import-assertion-trlng-comma.js (default)",
-  "language/module-code/import-assertion-trlng-comma.js (strict mode)",
-  "language/module-code/import-assertion-value-string-double.js (default)",
-  "language/module-code/import-assertion-value-string-double.js (strict mode)",
-  "language/module-code/import-assertion-value-string-single.js (default)",
-  "language/module-code/import-assertion-value-string-single.js (strict mode)",
   "language/expressions/dynamic-import/2nd-param-assert-enumeration-abrupt.js (default)",
   "language/expressions/dynamic-import/2nd-param-assert-enumeration-abrupt.js (strict mode)",
   "language/expressions/dynamic-import/2nd-param-assert-enumeration.js (default)",

--- a/src/index.js
+++ b/src/index.js
@@ -216,10 +216,6 @@ export function importAssertions(Parser) {
         this.next();
         node.key = assertionKeyNode;
 
-        // for now we are only allowing `type` as the only allowed module attribute
-        if (node.key.name !== "type") {
-          this.raise(this.pos, "The only accepted import assertion is `type`");
-        }
         // check if we already have an entry for an attribute
         // if a duplicate entry is found, throw an error
         // for now this logic will come into play only when someone declares `type` twice

--- a/test/fixtures/unsupported-key/expected.json
+++ b/test/fixtures/unsupported-key/expected.json
@@ -1,3 +1,165 @@
 {
-  "error": "The only accepted import assertion is `type` (1:50)"
+  "type": "Program",
+  "start": 0,
+  "end": 54,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    54
+  ],
+  "body": [
+    {
+      "type": "ImportDeclaration",
+      "start": 0,
+      "end": 53,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 53
+        }
+      },
+      "range": [
+        0,
+        53
+      ],
+      "specifiers": [
+        {
+          "type": "ImportDefaultSpecifier",
+          "start": 7,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            }
+          },
+          "range": [
+            7,
+            11
+          ],
+          "local": {
+            "type": "Identifier",
+            "start": 7,
+            "end": 11,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            },
+            "range": [
+              7,
+              11
+            ],
+            "name": "json"
+          }
+        }
+      ],
+      "source": {
+        "type": "Literal",
+        "start": 17,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 17
+          },
+          "end": {
+            "line": 1,
+            "column": 29
+          }
+        },
+        "range": [
+          17,
+          29
+        ],
+        "value": "./foo.json",
+        "raw": "\"./foo.json\""
+      },
+      "assertions": [
+        {
+          "type": "ImportAttribute",
+          "start": 39,
+          "end": 50,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 39
+            },
+            "end": {
+              "line": 1,
+              "column": 50
+            }
+          },
+          "range": [
+            39,
+            50
+          ],
+          "key": {
+            "type": "Identifier",
+            "start": 39,
+            "end": 42,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 39
+              },
+              "end": {
+                "line": 1,
+                "column": 42
+              }
+            },
+            "range": [
+              39,
+              42
+            ],
+            "name": "abc"
+          },
+          "value": {
+            "type": "Literal",
+            "start": 44,
+            "end": 50,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 44
+              },
+              "end": {
+                "line": 1,
+                "column": 50
+              }
+            },
+            "range": [
+              44,
+              50
+            ],
+            "value": "json",
+            "raw": "\"json\""
+          }
+        }
+      ]
+    }
+  ],
+  "sourceType": "module"
 }


### PR DESCRIPTION
this PR removes the condition to require keys to be "type".
some unrelated tests were previously passing, and are correctly failing now, others are passing which previously failed.

before:

```
Summary:
 ✔ 31 valid programs parsed without error
 ✔ 7 invalid programs produced a parsing error
 ✔ 4 invalid programs did not produce a parsing error (and allowed by the whitelist file)
 ✔ 127 valid programs produced a parsing error (and allowed by the whitelist file)
 ✔ 80495 programs were skipped
```


after:
```
Summary:
 ✔ 45 valid programs parsed without error
 ✔ 1 invalid programs produced a parsing error
 ✔ 10 invalid programs did not produce a parsing error (and allowed by the whitelist file)
 ✔ 113 valid programs produced a parsing error (and allowed by the whitelist file)
 ✔ 80495 programs were skipped
```