### PR TITLE
Allow parsing the `with` keyword for import attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export function importAssertions(Parser) {
         if (this.type !== tt.string) { this.unexpected(); }
         node.source = this.parseExprAtom();
 
-        if (this.type === this.assertToken) {
+        if (this.type === this.assertToken || this.type === tt._with) {
           this.next();
           const assertions = this.parseImportAssertions();
           if (assertions) {
@@ -140,7 +140,7 @@ export function importAssertions(Parser) {
           if (this.type !== tt.string) { this.unexpected(); }
           node.source = this.parseExprAtom();
 
-          if (this.type === this.assertToken) {
+          if (this.type === this.assertToken || this.type === tt._with) {
             this.next();
             const assertions = this.parseImportAssertions();
             if (assertions) {
@@ -177,7 +177,7 @@ export function importAssertions(Parser) {
           this.type === tt.string ? this.parseExprAtom() : this.unexpected();
       }
 
-      if (this.type === this.assertToken) {
+      if (this.type === this.assertToken || this.type == tt._with) {
         this.next();
         const assertions = this.parseImportAssertions();
         if (assertions) {

--- a/test/fixtures/with-keyword-export-all/actual.js
+++ b/test/fixtures/with-keyword-export-all/actual.js
@@ -1,0 +1,1 @@
+export * from "./foo.json" with { type: "json" };

--- a/test/fixtures/with-keyword-export-all/expected.json
+++ b/test/fixtures/with-keyword-export-all/expected.json
@@ -1,0 +1,125 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 50,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    50
+  ],
+  "body": [
+    {
+      "type": "ExportAllDeclaration",
+      "start": 0,
+      "end": 49,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 49
+        }
+      },
+      "range": [
+        0,
+        49
+      ],
+      "exported": null,
+      "source": {
+        "type": "Literal",
+        "start": 14,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 14
+          },
+          "end": {
+            "line": 1,
+            "column": 26
+          }
+        },
+        "range": [
+          14,
+          26
+        ],
+        "value": "./foo.json",
+        "raw": "\"./foo.json\""
+      },
+      "assertions": [
+        {
+          "type": "ImportAttribute",
+          "start": 34,
+          "end": 46,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 34
+            },
+            "end": {
+              "line": 1,
+              "column": 46
+            }
+          },
+          "range": [
+            34,
+            46
+          ],
+          "key": {
+            "type": "Identifier",
+            "start": 34,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 34
+              },
+              "end": {
+                "line": 1,
+                "column": 38
+              }
+            },
+            "range": [
+              34,
+              38
+            ],
+            "name": "type"
+          },
+          "value": {
+            "type": "Literal",
+            "start": 40,
+            "end": 46,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 40
+              },
+              "end": {
+                "line": 1,
+                "column": 46
+              }
+            },
+            "range": [
+              40,
+              46
+            ],
+            "value": "json",
+            "raw": "\"json\""
+          }
+        }
+      ]
+    }
+  ],
+  "sourceType": "module"
+}

--- a/test/fixtures/with-keyword-export-named/actual.js
+++ b/test/fixtures/with-keyword-export-named/actual.js
@@ -1,0 +1,1 @@
+export { json } from "./foo.json" with { type: "json" };

--- a/test/fixtures/with-keyword-export-named/expected.json
+++ b/test/fixtures/with-keyword-export-named/expected.json
@@ -1,0 +1,186 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 57,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    57
+  ],
+  "body": [
+    {
+      "type": "ExportNamedDeclaration",
+      "start": 0,
+      "end": 56,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 56
+        }
+      },
+      "range": [
+        0,
+        56
+      ],
+      "declaration": null,
+      "specifiers": [
+        {
+          "type": "ExportSpecifier",
+          "start": 9,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            }
+          },
+          "range": [
+            9,
+            13
+          ],
+          "local": {
+            "type": "Identifier",
+            "start": 9,
+            "end": 13,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "range": [
+              9,
+              13
+            ],
+            "name": "json"
+          },
+          "exported": {
+            "type": "Identifier",
+            "start": 9,
+            "end": 13,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "range": [
+              9,
+              13
+            ],
+            "name": "json"
+          }
+        }
+      ],
+      "source": {
+        "type": "Literal",
+        "start": 21,
+        "end": 33,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 21
+          },
+          "end": {
+            "line": 1,
+            "column": 33
+          }
+        },
+        "range": [
+          21,
+          33
+        ],
+        "value": "./foo.json",
+        "raw": "\"./foo.json\""
+      },
+      "assertions": [
+        {
+          "type": "ImportAttribute",
+          "start": 41,
+          "end": 53,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 41
+            },
+            "end": {
+              "line": 1,
+              "column": 53
+            }
+          },
+          "range": [
+            41,
+            53
+          ],
+          "key": {
+            "type": "Identifier",
+            "start": 41,
+            "end": 45,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 41
+              },
+              "end": {
+                "line": 1,
+                "column": 45
+              }
+            },
+            "range": [
+              41,
+              45
+            ],
+            "name": "type"
+          },
+          "value": {
+            "type": "Literal",
+            "start": 47,
+            "end": 53,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 47
+              },
+              "end": {
+                "line": 1,
+                "column": 53
+              }
+            },
+            "range": [
+              47,
+              53
+            ],
+            "value": "json",
+            "raw": "\"json\""
+          }
+        }
+      ]
+    }
+  ],
+  "sourceType": "module"
+}

--- a/test/fixtures/with-keyword-import/actual.js
+++ b/test/fixtures/with-keyword-import/actual.js
@@ -1,0 +1,1 @@
+import json from "./foo.json" with { type: "json" };

--- a/test/fixtures/with-keyword-import/expected.json
+++ b/test/fixtures/with-keyword-import/expected.json
@@ -1,0 +1,165 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 53,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    53
+  ],
+  "body": [
+    {
+      "type": "ImportDeclaration",
+      "start": 0,
+      "end": 52,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 52
+        }
+      },
+      "range": [
+        0,
+        52
+      ],
+      "specifiers": [
+        {
+          "type": "ImportDefaultSpecifier",
+          "start": 7,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            }
+          },
+          "range": [
+            7,
+            11
+          ],
+          "local": {
+            "type": "Identifier",
+            "start": 7,
+            "end": 11,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            },
+            "range": [
+              7,
+              11
+            ],
+            "name": "json"
+          }
+        }
+      ],
+      "source": {
+        "type": "Literal",
+        "start": 17,
+        "end": 29,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 17
+          },
+          "end": {
+            "line": 1,
+            "column": 29
+          }
+        },
+        "range": [
+          17,
+          29
+        ],
+        "value": "./foo.json",
+        "raw": "\"./foo.json\""
+      },
+      "assertions": [
+        {
+          "type": "ImportAttribute",
+          "start": 37,
+          "end": 49,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 37
+            },
+            "end": {
+              "line": 1,
+              "column": 49
+            }
+          },
+          "range": [
+            37,
+            49
+          ],
+          "key": {
+            "type": "Identifier",
+            "start": 37,
+            "end": 41,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 37
+              },
+              "end": {
+                "line": 1,
+                "column": 41
+              }
+            },
+            "range": [
+              37,
+              41
+            ],
+            "name": "type"
+          },
+          "value": {
+            "type": "Literal",
+            "start": 43,
+            "end": 49,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 43
+              },
+              "end": {
+                "line": 1,
+                "column": 49
+              }
+            },
+            "range": [
+              43,
+              49
+            ],
+            "value": "json",
+            "raw": "\"json\""
+          }
+        }
+      ]
+    }
+  ],
+  "sourceType": "module"
+}


### PR DESCRIPTION
This PR adds support for the `with` keyword, given that the proposal has recently been changed to https://github.com/tc39/proposal-import-attributes.

My goal is to have as few changes as possible (no new package, no AST changes, no major release), so that it will be transparently supported by the rest of the ecosystem:
- Every version of Rollup that ever supported import assertions depends on version `^1.8.0` of this package (https://github.com/rollup/rollup/pull/4646)
- Webpack >= 5.48.0 (released in Aud 2021) depends on version ^1.7.6 of this package (https://github.com/webpack/webpack/pull/13815)

Releasing this PR as version 1.9.0 will retroactively add support for import attributes to Webpack and Rollup, helping the community to migrate.

cc @lukastaegert @TheLarkinn